### PR TITLE
removed EIPA course from upcoming events and added to activities in EN and NL

### DIFF
--- a/content/english/_index.md
+++ b/content/english/_index.md
@@ -71,13 +71,6 @@ Activity_Feed:
   items_title: Upcoming events
   activities:
     - title: >-
-        Course on 'AI Risk Management in the EU', European Institute of Public Administration
-      link: >-
-        https://www.eipa.eu/courses/artificial-intelligence/
-      image: /images/partner logo-cropped/EIPA.png
-      date: 18-11-2025
-      type: training
-    - title: >-
         ODI Europe & UN Women 'Governing the Algorithm: Embedding Gender Equality in Europe’s Digital Future '
       link: >-
         https://odi.org/en/about/our-work/odi-europe/

--- a/content/english/events/activities.md
+++ b/content/english/events/activities.md
@@ -27,7 +27,24 @@ facet_groups:
         label: Panel discussion
       - value: presentation
         label: Presentation
+      - value: training
+        label: Training
 events:
+  - title: >-
+      Course on 'AI Risk Management in the EU', European Institute of Public Administration
+    description: >
+      This intensive two-day course by the ['European Institute of Public Administration'](https://www.eipa.eu/) (EIPA) offered a deep dive into AI compliance and risk management in the EU. Participants became familiar with the EU AI Act’s risk-based approach and explored its interplay with the larger digital regulatory frameworks, thereby gaining a rich understanding of their impact on AI development, deployment, and governance.
+    image: /images/partner logo-cropped/EIPA.png
+    date: 18-11-2025
+    facets:
+      - value: year_2025
+        label: '2025'
+        hide: true
+      - value: year_q4_2025
+        label: Q4-2025
+        hide: true
+      - value: type_training
+        label: training
   - title: >-
       AI Act Implementation Congres, The Netherlands AI Coalition
     description: >

--- a/content/nederlands/_index.md
+++ b/content/nederlands/_index.md
@@ -74,13 +74,6 @@ Activity_Feed:
   items_title: Aankomende events
   activities:
     - title: >-
-        Cursus 'AI risicomanagement in de EU', European Institute of Public Administration
-      link: >-
-        https://www.eipa.eu/courses/artificial-intelligence/
-      image: /images/partner logo-cropped/EIPA.png
-      date: 18-11-2025
-      type: training
-    - title: >-
         ODI Europe & UN Women 'Governing the Algorithm: Embedding Gender Equality in Europe’s Digital Future '
       link: >-
         https://odi.org/en/about/our-work/odi-europe/

--- a/content/nederlands/events/activities.md
+++ b/content/nederlands/events/activities.md
@@ -25,7 +25,24 @@ facet_groups:
         label: Paneldiscussie
       - value: presentation
         label: Presentatie
+      - value: training
+        label: Training
 events:
+  - title: >-
+      Cursus 'AI risicomanagement in de EU', European Institute of Public Administration
+    description: >
+      Deze intensieve tweedaagse cursus van het [‘European Institute of Public Administration’](https://www.eipa.eu/) (EIPA) bood een diepgaande kijk op AI-compliance en risicobeheer in de EU. Deelnemers raakten vertrouwd met de risicogebaseerde aanpak van de EU-AI-verordening en verkenden de wisselwerking met de bredere digitale regelgevingskaders, waardoor ze een goed inzicht kregen in de impact ervan op de ontwikkeling, implementatie en governance van AI.
+    image: /images/partner logo-cropped/EIPA.png
+    date: 18-11-2025
+    facets:
+      - value: year_2025
+        label: '2025'
+        hide: true
+      - value: year_q4_2025
+        label: Q4-2025
+        hide: true
+      - value: type_training
+        label: training
   - title: >-
       AI-verordening Implementatie Congres, AI Coalitie 4NL  
     description: >


### PR DESCRIPTION
Removed the EIPA event 'Course on AI Risk Management in the EU' (https://www.eipa.eu/courses/artificial-intelligence/) from the upcoming events on the home page and added to activities in the events page.

- removed from index.md on home page in EN and NL
- added to activities.md in events folder in EN and NL
    - added new type facet for training, value training, label Training
    - description translated with DeepL
    - description hyperlink to EIPA homepage since event page will likely expire