### PR TITLE
juiste link naar 2e DUO rapport in project work EN en NL

### DIFF
--- a/content/english/knowledge-platform/project-work.md
+++ b/content/english/knowledge-platform/project-work.md
@@ -170,7 +170,7 @@ From Q3-2024 up to Q1-2025, Algorithm Audit assisted the Municipality of Amsterd
 From Q3-2023 up to Q2-2024, Algorithm Audit assisted the Dutch Executive Eductaion Agency's (DUO) with an internal investigation into an allegedly biased algorithmic-driven decision-making process.
 
 - The first [audit report](/algoprudence/cases/aa202401_preventing-prejudice/) was sent to DUO and Dutch Parliament on 01-01-2024;
-- The second [audit report](/algoprudence/cases/aa202401_preventing-prejudice/) was sent to DUO and Dutch Parliament on 22-05-2024.
+- The second [audit report](/algoprudence/cases/aa202402_preventing-prejudice_addendum/) was sent to DUO and Dutch Parliament on 22-05-2024.
 
 {{< image image1="/images/partner logo-cropped/DUO.png" alt1="Dutch Executive Education Agency (DUO)" caption1="Dutch Executive Education Agency (DUO)" link1="" width_desktop="3" id="DUO-logo" >}}
 

--- a/content/nederlands/knowledge-platform/project-work.md
+++ b/content/nederlands/knowledge-platform/project-work.md
@@ -170,7 +170,7 @@ Van Q3-2024 tot en met Q1-2025 werkte Algorithm Audit samen met de Gemeente Amst
 Van Q3-2023 tot en met Q2-2024 ondersteunde Algorithm Audit de Dienst Uitvoering Onderwijs (DUO) bij een intern onderzoek naar een naar verluid bevooroordeeld algoritme-gedreven besluitvormingsproces.
 
 - Het eerste [auditrapport](/algoprudence/cases/aa202401_preventing-prejudice/) is op 01-01-2024 aan DUO en de Tweede Kamer aangeboden;
-- Het tweede [auditrapport](/algoprudence/cases/aa202401_preventing-prejudice/) is op 22-05-2024 aan DUO en de Tweede Kamer aangeboden.
+- Het tweede [auditrapport](/algoprudence/cases/aa202402_preventing-prejudice_addendum/) is op 22-05-2024 aan DUO en de Tweede Kamer aangeboden.
 
 {{< image image1="/images/partner logo-cropped/DUO.png" alt1="Dienst Uitvoering Onderwijs (DUO)" caption1="Dienst Uitvoering Onderwijs (DUO)" link1="" width_desktop="3" id="DUO-logo" >}}
 


### PR DESCRIPTION
juiste link naar /algoprudence/cases/aa202402_preventing-prejudice_addendum/ ipv 2 keer naar aa202401 bij DUO case op pagina project work gezet